### PR TITLE
issues/#34-update-dependencies-version

### DIFF
--- a/xyz-domain/pom.xml
+++ b/xyz-domain/pom.xml
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
-            <version>2.6.1-RC1</version>
+            <version>2.6.3</version>
             <scope>provided</scope>
         </dependency>
         -->
@@ -174,7 +174,7 @@
                     <dependency>
                         <groupId>org.eclipse.persistence</groupId>
                         <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
-                        <version>2.6.1-RC1</version>
+                        <version>2.6.3</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -227,7 +227,7 @@
                     <dependency>
                         <groupId>org.eclipse.persistence</groupId>
                         <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
-                        <version>2.6.1-RC1</version>
+                        <version>2.6.3</version>
                     </dependency>
                     <dependency>
                         <groupId>com.github.namioka.eclipselink-example</groupId>

--- a/xyz-infrastructures/xyz-persistence/pom.xml
+++ b/xyz-infrastructures/xyz-persistence/pom.xml
@@ -207,7 +207,7 @@
                 <dependency>
                     <groupId>fish.payara.extras</groupId>
                     <artifactId>payara-embedded-all</artifactId>
-                    <version>4.1.1.161.1</version>
+                    <version>4.1.1.162</version>
                     <scope>provided</scope>
                 </dependency>
                 <!--


### PR DESCRIPTION
 - org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.6.1-RC1 -> 2.6.3

 - fish.payara.extras:payara-embedded-all:4.1.1.161.1 -> 4.1.1.162

 On branch issues/#34-update-dependencies-version
 Changes to be committed:
	modified:   xyz-domain/pom.xml
	modified:   xyz-infrastructures/xyz-persistence/pom.xml

close #34 