### PR TITLE
issues/#35-Update-plugins-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,12 +328,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>3.5.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -374,7 +374,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.0.2</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -398,7 +398,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.0.0</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -427,7 +427,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>source-jar</id>
@@ -453,7 +453,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-changes-plugin</artifactId>
-                    <version>2.11</version>
+                    <version>2.12</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -473,7 +473,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
+                    <version>2.10.4</version>
                     <executions>
                         <execution>
                             <id>javadoc-jar</id>
@@ -507,7 +507,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.8.1</version>
+                    <version>2.9</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -588,7 +588,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>3.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -612,7 +612,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-scm-plugin</artifactId>
-                    <version>1.9.4</version>
+                    <version>1.9.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -632,17 +632,17 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>1.10</version>
+                    <version>1.12</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.2</version>
+                    <version>2.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.cargo</groupId>
                     <artifactId>cargo-maven2-plugin</artifactId>
-                    <version>1.4.18</version>
+                    <version>1.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.maven.plugin</groupId>
@@ -652,7 +652,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.6.201602180812</version>
+                    <version>0.7.7.201606060606</version>
                     <executions>
                         <execution>
                             <goals>
@@ -671,7 +671,7 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>2.11</version>
+                    <version>3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>net.revelc.code</groupId>


### PR DESCRIPTION
- org.apache.maven.plugins:maven-resources-plugin:2.7 -> 3.0.1
- org.apache.maven.plugins:maven-site-plugin:3.4 -> 3.5.1
- org.apache.maven.plugins:maven-jar-plugin:2.6 -> 3.0.2
- org.apache.maven.plugins:maven-war-plugin:2.6 -> 3.0.0
- org.apache.maven.plugins:maven-source-plugin:2.4 -> 3.0.1
- org.apache.maven.plugins:maven-changes-plugin:2.11 -> 2.12
- org.apache.maven.plugins:maven-javadoc-plugin:2.10.3 -> 2.10.4
- org.apache.maven.plugins:maven-project-info-reports-plugin:2.8.1 -> 2.9
- org.apache.maven.plugins:maven-plugin-plugin:3.4 -> 3.5
- org.apache.maven.plugins:maven-scm-plugin:1.9.4 -> 1.9.5
- org.codehaus.mojo:build-helper-maven-plugin:1.10 -> 1.12
- org.codehaus.mojo:versions-maven-plugin:2.2 -> 2.3
- org.codehaus.cargo:cargo-maven2-plugin:1.4.18 -> 1.5.0
- org.jacoco:jacoco-maven-plugin:0.7.6.201602180812 -> 0.7.7.201606060606
- com.mycila:license-maven-plugin:2.11 -> 3.0